### PR TITLE
fix to static_pathway_tab and views.py:pathway

### DIFF
--- a/network/lls_custom_functions.py
+++ b/network/lls_custom_functions.py
@@ -919,7 +919,7 @@ def gene_to_lab_id (genes, labids, request, config_struct_nodes, cur_graph):
 def get_pathways_sample (request, request_post):
     
     import config
-    
+    print request_post
     subj_nodes = map(lambda x:{'node_type':'Sample', 'id':x}, request_post['sample_name'])
     query_nodes = map(lambda x:{'node_type':'Pathway', 'id':x}, request_post['pathway_name'])
     

--- a/network/templates/network/d3_test.html
+++ b/network/templates/network/d3_test.html
@@ -151,6 +151,8 @@
                                 
                                 input_vals['panel_context'] = panel_context;
                                 
+                                console.log(JSON.stringify(input_vals))
+                                
                                 $.post("{{prog_type}}/HitWalker2/get_graph/", input_vals, function(data, status, xhr)
                                                {
                                                     if (status == "success")
@@ -606,7 +608,30 @@
                 
                 var form = document.getElementById("pathform");
                 form['pathway_name'].value = sel_vals[0].replace(/\s+\(n=\d+\)/, "");
-                form['sample_name'].value = d3.select(popover_ref).datum().id;
+                
+                //form['sample_name'].value = d3.select(popover_ref).datum().id;
+                
+                var ret_samples = []
+                
+                selected_node.forEach(function(key, value)
+                          {
+                                var cur_val = d3.select(value).datum();
+                                var temp_nodes = [];
+                                
+                                if (cur_val.attributes.node_type == 'MetaNode')
+                                {
+                                    temp_nodes = $.map(cur_val.children, function(x) {return(x.id)});
+                                }else{
+                                    temp_nodes.push(cur_val.id)
+                                }
+                                
+                                $.merge(ret_samples, temp_nodes)
+                          });
+                
+                console.log(JSON.stringify(ret_samples))
+                
+                form['sample_name'].value = ret_samples
+                
                 form.target='_blank';
                 form.submit();
                 

--- a/network/views.py
+++ b/network/views.py
@@ -605,8 +605,8 @@ def pathway(request):
     else:
         request_post = dict(request.POST.iterlists())
         
-        input_vals = {'sample_name':request.POST['sample_name'], 'pathway_name':request.POST['pathway_name']}
-        
+        #as multiple samples can be specified and they will be sent ',' delimited by the JS:
+        input_vals = {'sample_name':request.POST['sample_name'].split(','), 'pathway_name':request.POST['pathway_name']}
         
         inp_params = request.session['inp_params']
         where_vars = request.session['where_vars']
@@ -622,6 +622,7 @@ def pathway(request):
         for i in where_vars:
             cur_filts[i['name']] = i['pretty_where']
         
+        print input_vals
         
         ret_json = {'prog_type':str(prog_type), 'username':str(request.user), 'node_type_transl':json.dumps(config.node_abbreviations), 'edge_type_transl':json.dumps(config.edge_abbreviations),
                     'metanode_thresh':config.max_nodes, 'panel_context':'image', 'input_vals':json.dumps(input_vals), 'cur_param':json.dumps(cur_param), 'cur_filts':json.dumps(cur_filts)}


### PR DESCRIPTION
fix to static_pathway_tab to reliably send back the names of several samples/metanodes

fix to views.py:pathway to interpret samples as being delimited by ',' and so now splits them
